### PR TITLE
Fix https//: typo in Mastodon API-Token URL example

### DIFF
--- a/Mastodon/README.md
+++ b/Mastodon/README.md
@@ -78,7 +78,7 @@ Elk.zone is a web client for Mastodon. This action combines [search](#1-search-a
 
 ## API-Token 
 
-Go to "https//:`your.server`/settings/applications/". (If you came here from the dialog in the action that link should have opened automatically along with this one.) Then click the `New application` button. 
+Go to "https://`your.server`/settings/applications/". (If you came here from the dialog in the action that link should have opened automatically along with this one.) Then click the `New application` button. 
 
 You need the following permissions:
 


### PR DESCRIPTION
Line 81 of `Mastodon/README.md` shows the URL pattern users should visit to create an API token, but the protocol is written as `https//:` (slashes/colon swapped). Fixed to `https://`.